### PR TITLE
free resources of TCommonMsgClientHandler only once

### DIFF
--- a/DnMsgClient.pas
+++ b/DnMsgClient.pas
@@ -925,9 +925,9 @@ end;
 
 destructor TCommonMsgClientHandler.Destroy;
 begin
-  FDestroying := True;
   if FDestroying then
     exit;
+  FDestroying := True;
   //FreeAndNil(FStreamInfo);
   FreeAndNil(FClientList);
 {$IFNDEF USECONNECTFIBER}


### PR DESCRIPTION
EurekaLog shows such memory leak:

![Screenshot_9](https://user-images.githubusercontent.com/2838600/78247617-d2c19b80-74f3-11ea-80db-5fca3550cdca.png)

In this case EurekaLog points to memory that allocated for ``FClientList``. But if we open destructor we really can see that ``FClientList`` will never be emptied